### PR TITLE
Give Picard access to all devices

### DIFF
--- a/org.musicbrainz.Picard.json
+++ b/org.musicbrainz.Picard.json
@@ -10,6 +10,7 @@
         "--share=ipc",
         "--socket=x11",
         "--share=network",
+        "--device=all",
         "--filesystem=home",
         "--filesystem=xdg-music",
         "--talk-name=org.gnome.GConf"


### PR DESCRIPTION
This is unfortunately necessary to access CDs and DVDs, until Flatpak
grows something more contained:

https://github.com/flatpak/flatpak/issues/12