### PR TITLE
Bump to Picard 2.1.3

### DIFF
--- a/org.musicbrainz.Picard.json
+++ b/org.musicbrainz.Picard.json
@@ -195,8 +195,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/metabrainz/picard.git",
-                    "tag": "release-2.1.1",
-                    "commit": "bc587133d5dbf1f9bcc1cb00b2a09a0e05a5ce1d"
+                    "tag": "release-2.1.3",
+                    "commit": "5b3e83120d2c0baeed4e14d5581c3cba29f8c605"
                 }
             ]
         }


### PR DESCRIPTION
We released a new version 2.1.3 with quite a few fixes. See https://github.com/metabrainz/picard/releases/tag/release-2.1.3 for details.

For you interesting: The appdata file should now be always up-to-date since we fill the release list during build.