### PR TITLE
Add the dependencies for the bpm plugin

### DIFF
--- a/org.musicbrainz.Picard.json
+++ b/org.musicbrainz.Picard.json
@@ -188,6 +188,44 @@
             ]
         },
         {
+            "name": "bpm-plugin-dep-numpy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "${PIP} install --no-deps --prefix=${FLATPAK_DEST} ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://files.pythonhosted.org/packages/source/n/numpy/numpy-1.17.2.zip",
+                    "sha256": "73615d3edc84dd7c4aeb212fa3748fb83217e00d201875a47327f55363cef2df"
+                }
+            ],
+            "cleanup": [
+                "/bin",
+                "/lib/python3.*/site-packages/numpy/core/include",
+                "/lib/python3.*/site-packages/numpy/core/lib/libnpymath.a",
+                "/lib/python3.*/site-packages/numpy/tests",
+                "/lib/python3.*/site-packages/numpy/*/tests"
+            ]
+        },
+        {
+            "name": "bpm-plugin-dep-aubio",
+            "buildsystem": "simple",
+            "build-commands": [
+                "${PIP} install --no-deps --prefix=${FLATPAK_DEST} ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://files.pythonhosted.org/packages/source/a/aubio/aubio-0.4.9.tar.gz",
+                    "sha256": "df1244f6c4cf5bea382c8c2d35aa43bc31f4cf631fe325ae3992c219546a4202"
+                }
+            ],
+            "cleanup": [
+                "/bin"
+            ]
+        },
+        {
             "name": "picard",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
Picard has a system to install and load plugins. However some of those
plugins have dependencies, and Picard won't install them.

The BPM plugin is a very popular one which requires 2 additional Python
modules.

Upstream says this should be the only popular plugin with dependencies,
so it should be ok for us to bundle them.

Hopefully we won't have to bundle much more, as that would eventually
start being harmful to all users who don't use those plugins.

Eventually Picard itself might improve its plugin system to the point it
installs plugins with their dependencies, and we will be able to remove
those modules from the Flatpak build.

The two new modules are named "bpm-plugin-dep-* to clearly identify them
as dependencies of a plugin, not Picard itself, so that it is easier to
remove them when the time comes.

Fixes #35