### PR TITLE
Mount the host /tmp in the sandbox

### DIFF
--- a/org.musicbrainz.Picard.json
+++ b/org.musicbrainz.Picard.json
@@ -12,7 +12,8 @@
         "--share=network",
         "--device=all",
         "--filesystem=home",
-        "--filesystem=xdg-music"
+        "--filesystem=xdg-music",
+        "--filesystem=/tmp"
     ],
     "build-options": {
         "env": {


### PR DESCRIPTION
For some of its operations, Picard creates a temporary HTML file in
/tmp, then through a series of Python modules calls xdg-open to open it
in a web browser.

Since the web browser is outside the sandbox, this obviously can't work
unless the HTML file is accessible on the outside.

This commit mounts the host /tmp in the sandbox to make the temporary
HTML file created by Picard accessible by web browsers.

Fixes #38