### PR TITLE
Disable i386 build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "only-arches": ["x86_64", "i386"]
+    "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
FreeDesktop 19.08 dropped support for 32-bit Intel CPUs