### PR TITLE
Revert "Bump chromaprint from 1.4.3 to 1.5.0"

### DIFF
--- a/org.musicbrainz.Picard.json
+++ b/org.musicbrainz.Picard.json
@@ -213,8 +213,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/acoustid/chromaprint/releases/download/v1.5.0/chromaprint-1.5.0.tar.gz",
-                    "sha256": "573a5400e635b3823fc2394cfa7a217fbb46e8e50ecebd4a61991451a8af766a"
+                    "url": "https://github.com/acoustid/chromaprint/releases/download/v1.4.3/chromaprint-1.4.3.tar.gz",
+                    "sha256": "ea18608b76fb88e0203b7d3e1833fb125ce9bb61efe22c6e169a50c52c457f82"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
This reverts commit c9a19af3e049236a532ead2f0c95a8310d28d658.

Closes #56.