### PR TITLE
Upgrade to mutagen 1.45.1

### DIFF
--- a/org.musicbrainz.Picard.json
+++ b/org.musicbrainz.Picard.json
@@ -260,8 +260,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/source/m/mutagen/mutagen-1.44.0.tar.gz",
-                    "sha256": "56065d8a9ca0bc64610a4d0f37e2bd4453381dde3226b8835ee656faa3287be4"
+                    "url": "https://files.pythonhosted.org/packages/source/m/mutagen/mutagen-1.45.1.tar.gz",
+                    "sha256": "6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
Upgrade to latest mutagen 1.45.1 release.

See the relevant changelogs at https://mutagen.readthedocs.io/en/latest/changelog.html

Most notably the 1.45.1 release improves performance when saving on some file systems without nmap support. Also this will enable DSF and WAVE support once the Picard 2.4 release is out.